### PR TITLE
Pass config as absolute path

### DIFF
--- a/src/ModuleResolver.ts
+++ b/src/ModuleResolver.ts
@@ -92,7 +92,7 @@ export class ModuleResolver {
     if (matchedPaths.length !== 0) {
       this.loggingService.logDebug(CONFIG_PATHS_FOUND_FOR_WORKSPACE, { workspace: workspaceFolder.uri.fsPath, found: matchedPaths });
 
-      executableArgs['--config'] = workspace.asRelativePath(matchedPaths[0]);
+      executableArgs['--config'] = matchedPaths[0];
     } else {
       this.loggingService.logDebug(NO_CONFIG_FOUND_FOR_WORKSPACE, workspaceFolder.uri.fsPath);
     }


### PR DESCRIPTION
This fixes an issue where the config would not be properly loaded when not located in the root of the workspace